### PR TITLE
Sax parser on hex is way nicer than the xmerl one in the erlang stdlib

### DIFF
--- a/lib/exkml/helpers.ex
+++ b/lib/exkml/helpers.ex
@@ -1,16 +1,16 @@
 defmodule Exkml.Helpers do
   defmacro on_enter(name, event, state, body) do
     quote do
-      def on_event({:startElement, _, unquote(name), _, _} = unquote(event), _, unquote(state)) do
-        unquote(body[:do])
+      def handle_event(:start_element, {unquote(name), _attrs} = unquote(event), unquote(state)) do
+        {:ok, unquote(body[:do])}
       end
     end
   end
 
-  defmacro on_exit(name, event, state, body) do
+  defmacro on_exit(name, state, body) do
     quote do
-      def on_event({:endElement, _, unquote(name), _} = unquote(event), _, unquote(state)) do
-        unquote(body[:do])
+      def handle_event(:end_element, unquote(name), unquote(state)) do
+        {:ok, unquote(body[:do])}
       end
     end
   end
@@ -19,12 +19,11 @@ defmodule Exkml.Helpers do
     stack = path
     |> String.split("/")
     |> Enum.reverse
-    |> Enum.map(&:erlang.binary_to_list/1)
 
     quote do
-      def on_event({:characters, c}, _, %{stack: unquote(stack)} = unquote(state)) do
-        var!(text) = :erlang.list_to_binary(c)
-        unquote(body[:do])
+      def handle_event(:characters, c, %{stack: unquote(stack)} = unquote(state)) do
+        var!(text) = c
+        {:ok, unquote(body[:do])}
       end
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,8 @@ defmodule Exkml.Mixfile do
   def project do
     [
       app: :exkml,
-      version: "0.2.6",
-      elixir: "~> 1.5",
+      version: "0.3.0",
+      elixir: "~> 1.7",
       start_permanent: Mix.env == :prod,
       deps: deps(),
       description: description(),

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,8 @@ defmodule Exkml.Mixfile do
   defp deps do
     [
       {:ex_doc, ">= 0.0.0", only: :dev},
-      {:gen_stage, "~> 0.8.0"}
+      {:gen_stage, "~> 0.8.0"},
+      {:saxy, "~> 0.7.0"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,8 @@
-%{"earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], []},
+%{
+  "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.16.4", "4bf6b82d4f0a643b500366ed7134896e8cccdbab4d1a7a35524951b25b1ec9f0", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
-  "gen_stage": {:hex, :gen_stage, "0.8.0", "a76e3f0530f86fae8b8a1021c06527b1ec171cf4c0bdfecd8d5ad0376d1205af", [:mix], []}}
+  "fast_xml": {:hex, :fast_xml, "1.1.28", "31ce5cf44d20e900e1a499009f886ff74b589324d532ed0ed7a432e4f498beb1", [], [{:p1_utils, "1.0.10", [hex: :p1_utils, repo: "hexpm", optional: false]}], "hexpm"},
+  "gen_stage": {:hex, :gen_stage, "0.8.0", "a76e3f0530f86fae8b8a1021c06527b1ec171cf4c0bdfecd8d5ad0376d1205af", [:mix], []},
+  "p1_utils": {:hex, :p1_utils, "1.0.10", "a6d6927114bac79cf6468a10824125492034af7071adc6ed5ebc4ddb443845d4", [], [], "hexpm"},
+  "saxy": {:hex, :saxy, "0.7.0", "2b0a838583152f08be46313c4e0d2d47f2e2d021010154ca106940166797fd78", [], [], "hexpm"},
+}

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 while inotifywait -r -e modify ./test ./lib; do
-  mix test test/exkml_test.exs
+  mix test $1
 done

--- a/test/exkml_test.exs
+++ b/test/exkml_test.exs
@@ -304,6 +304,7 @@ defmodule ExkmlTest do
     end)
   end
 
+  @tag timeout: 1000
   test "malformed" do
     assert_raise Exkml.KMLParseError, ~r"ended prematurely", fn ->
       "malformed_kml"


### PR DESCRIPTION
* it doesn't gobble memory
* it has sane error handling
* it uses elixir binaries rather than erlang strings
* it has a much nicer API