### PR TITLE
Fix point parsing

### DIFF
--- a/lib/exkml.ex
+++ b/lib/exkml.ex
@@ -45,8 +45,8 @@ defmodule Exkml do
 
   def str_to_point(point_str) do
     point_str
-    |> String.trim
     |> String.split(",")
+    |> Enum.map(&String.trim/1)
     |> do_str_to_point
     |> case do
       :error -> {:error, "Invalid point #{point_str}"}

--- a/test/fixtures/simple_points.kml
+++ b/test/fixtures/simple_points.kml
@@ -18,7 +18,7 @@
 		<SimpleData name="a_float">2.2</SimpleData>
 		<SimpleData name="a_bool">false</SimpleData>
 	</SchemaData></ExtendedData>
-      <Point><coordinates>102.0,0.5</coordinates></Point>
+      <Point><coordinates>102.0, 0.5</coordinates></Point>
   </Placemark>
   <Placemark>
 	<ExtendedData><SchemaData schemaUrl="#OGRGeoJSON">
@@ -28,6 +28,6 @@
 		<SimpleData name="a_float">2.2</SimpleData>
 		<SimpleData name="a_bool">true</SimpleData>
 	</SchemaData></ExtendedData>
-      <Point><coordinates>103.0,1.5</coordinates></Point>
+      <Point><coordinates>103.0, 1.5</coordinates></Point>
   </Placemark>
 </Folder></Document></kml>


### PR DESCRIPTION
It wanted coordinates to be "x,y" but it appears whitespace is allowed
to appear.  So trim after splitting instead of before.