### PR TITLE
Alternate point-and-line parsing

### DIFF
--- a/test/fixtures/simple_lines.kml
+++ b/test/fixtures/simple_lines.kml
@@ -11,13 +11,13 @@
 	<ExtendedData><SchemaData schemaUrl="#OGRGeoJSON">
 		<SimpleData name="a_string">first value</SimpleData>
 	</SchemaData></ExtendedData>
-      <LineString><coordinates>100,0 101,1</coordinates></LineString>
+      <LineString><coordinates>100, 0 101, 1</coordinates></LineString>
   </Placemark>
   <Placemark>
 	<Style><LineStyle><color>ff0000ff</color></LineStyle><PolyStyle><fill>0</fill></PolyStyle></Style>
 	<ExtendedData><SchemaData schemaUrl="#OGRGeoJSON">
 		<SimpleData name="a_string">second value</SimpleData>
 	</SchemaData></ExtendedData>
-      <LineString><coordinates>101,0 101,1</coordinates></LineString>
+      <LineString><coordinates>101, 0 101, 1</coordinates></LineString>
   </Placemark>
 </Folder></Document></kml>


### PR DESCRIPTION
Lines also had the interior-whitespace sensitivity, so rewrite the parser
to scan from left to right rather than splitting on whitespace and then
parsing the bits.