### PR TITLE
Catch crash in the parsing process on unexpected element start

### DIFF
--- a/lib/exkml.ex
+++ b/lib/exkml.ex
@@ -380,14 +380,18 @@ defmodule Exkml do
     me = self()
     ref = make_ref()
     spawn_link(fn ->
-      Saxy.parse_stream(binstream, __MODULE__, %State{
-        receiver: me,
-        receiver_ref: ref
-      })
-      |> case do
-        {:ok, _} -> :ok
-        {:error, event} ->
-          send(me, {:error, ref, event})
+      try do
+        Saxy.parse_stream(binstream, __MODULE__, %State{
+          receiver: me,
+          receiver_ref: ref
+        })
+        |> case do
+          {:ok, _} -> :ok
+          {:error, event} ->
+            send(me, {:error, ref, event})
+        end
+      catch
+        kind, error -> send(me, {:error, ref, {kind, error}})
       end
     end)
 

--- a/test/exkml_test.exs
+++ b/test/exkml_test.exs
@@ -339,6 +339,24 @@ defmodule ExkmlTest do
     end
   end
 
+  @tag timeout: 1000
+  test "unexpected element start" do
+    assert_raise Exkml.KMLParseError, ~r"ended prematurely", fn ->
+      ["""
+      <?xml version="1.0" encoding="UTF-8"?>
+      <kml xmlns="http://www.opengis.net/kml/2.2">
+        <Document>
+          <name>KML Sample</name>
+          <Placemark>
+            <Point>
+            <Point>
+              <coordinates>-122.0822035425683,37.42228990140251,0</coordinates>
+            </Point>
+      """]
+      |> Exkml.stream!()
+      |> Enum.into([])
+    end
+  end
 
   Enum.each([
     {"boundaries", [Multigeometry], 163},


### PR DESCRIPTION
Prior to this change, the parsing process would crash without a clean error on the included test.